### PR TITLE
Update connectivity_util.dart

### DIFF
--- a/lib/src/connectivity_util.dart
+++ b/lib/src/connectivity_util.dart
@@ -18,7 +18,7 @@ class ConnectivityUtils {
   /// Server to ping
   ///
   /// The server to ping and check the response, can be set with [setServerToPing]
-  String _serverToPing = "http://www.google.com";
+  String _serverToPing = "http://www.gstatic.com/generate_204";
 
   /// Verify Response Callback
   ///
@@ -90,7 +90,7 @@ class ConnectivityUtils {
 
       // ignore: close_sinks
       final result = await http.get(_serverToPing);
-      if (result.statusCode == 200 && _callback(result.body)) {
+      if (result.statusCode > 199 && result.statusCode < 400 && _callback(result.body)) {
         return true;
       }
     } catch (e) {


### PR DESCRIPTION
Calling "http://www.gstatic.com/generate_204" instead of "google.com" might be more faster and better since google.com returns response body which will take some time also it costs more mobile data.

PS: `generate_204` is used for detecting internet connectivity in android, also used for prefetching DNS on chrome, google search and other google products.