### PR TITLE
updating connectivity widget with with flutter v2.0.0

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,8 +1,5 @@
-# Using a CDN with CocoaPods 1.7.2 or later can save a lot of time on pod installation, but it's experimental rather than the default.
-# source 'https://cdn.cocoapods.org/'
-
 # Uncomment this line to define a global platform for your project
-# platform :ios, '9.0'
+platform :ios, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -13,65 +10,37 @@ project 'Runner', {
   'Release' => :release,
 }
 
-def parse_KV_file(file, separator='=')
-  file_abs_path = File.expand_path(file)
-  if !File.exists? file_abs_path
-    return [];
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
   end
-  pods_ary = []
-  skip_line_start_symbols = ["#", "/"]
-  File.foreach(file_abs_path) { |line|
-      next if skip_line_start_symbols.any? { |symbol| line =~ /^\s*#{symbol}/ }
-      plugin = line.split(pattern=separator)
-      if plugin.length == 2
-        podname = plugin[0].strip()
-        path = plugin[1].strip()
-        podpath = File.expand_path("#{path}", file_abs_path)
-        pods_ary.push({:name => podname, :path => podpath});
-      else
-        puts "Invalid plugin specification: #{line}"
-      end
-  }
-  return pods_ary
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
 end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
 
 target 'Runner' do
   use_frameworks!
+  use_modular_headers!
 
-  # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
-  # referring to absolute paths on developers' machines.
-  system('rm -rf .symlinks')
-  system('mkdir -p .symlinks/plugins')
-
-  # Flutter Pods
-  generated_xcode_build_settings = parse_KV_file('./Flutter/Generated.xcconfig')
-  if generated_xcode_build_settings.empty?
-    puts "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first."
-  end
-  generated_xcode_build_settings.map { |p|
-    if p[:name] == 'FLUTTER_FRAMEWORK_DIR'
-      symlink = File.join('.symlinks', 'flutter')
-      File.symlink(File.dirname(p[:path]), symlink)
-      pod 'Flutter', :path => File.join(symlink, File.basename(p[:path]))
-    end
-  }
-
-  # Plugin Pods
-  plugin_pods = parse_KV_file('../.flutter-plugins')
-  plugin_pods.map { |p|
-    symlink = File.join('.symlinks', 'plugins', p[:name])
-    File.symlink(p[:path], symlink)
-    pod p[:name], :path => File.join(symlink, 'ios')
-  }
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
-
-# Prevent Cocoapods from embedding a second Flutter framework and causing an error with the new Xcode build system.
-install! 'cocoapods', :disable_input_output_paths => true
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+    # Specific configuration to run on pods
     target.build_configurations.each do |config|
-      config.build_settings['ENABLE_BITCODE'] = 'NO'
+      config.build_settings['ENABLE_BITCODE'] = 'YES'  # Enable Symbolic dYSM for pods (not all packages were distributed with bitcode enabled)
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '12.0'  # Ensure Platform Target for pods
     end
   end
 end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
   - Flutter (1.0.0)
   - Reachability (3.2)
-  - simple_connectivity (0.0.1):
+  - connectivity (0.0.1):
     - Flutter
     - Reachability
 
 DEPENDENCIES:
   - Flutter (from `.symlinks/flutter/ios`)
-  - simple_connectivity (from `.symlinks/plugins/simple_connectivity/ios`)
+  - connectivity (from `.symlinks/plugins/connectivity/ios`)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -16,13 +16,13 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   Flutter:
     :path: ".symlinks/flutter/ios"
-  simple_connectivity:
-    :path: ".symlinks/plugins/simple_connectivity/ios"
+  connectivity:
+    :path: ".symlinks/plugins/connectivity/ios"
 
 SPEC CHECKSUMS:
   Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
-  simple_connectivity: 84a7221f5ca3d54ebf18faa4d74f0bb6cc757cbe
+  connectivity: 84a7221f5ca3d54ebf18faa4d74f0bb6cc757cbe
 
 PODFILE CHECKSUM: 10ae9c18d12c9ffc2275c9a159a3b1e281990db0
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -7,10 +7,10 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     //setup connectivity server to ping and callback
-    ConnectivityUtils.initialize(
-        serverToPing:
-            "https://gist.githubusercontent.com/Vanethos/dccc4b4605fc5c5aa4b9153dacc7391c/raw/355ccc0e06d0f84fdbdc83f5b8106065539d9781/gistfile1.txt",
-        callback: (response) => response.contains("This is a test!"));
+    ConnectivityUtils.initialize(serverToPing: [
+      "gist.githubusercontent.com",
+      "Vanethos/dccc4b4605fc5c5aa4b9153dacc7391c/raw/355ccc0e06d0f84fdbdc83f5b8106065539d9781/gistfile1.txt"
+    ], callback: (response) => response.contains("This is a test!"));
 
     return MaterialApp(
       title: 'Flutter Demo',
@@ -65,7 +65,7 @@ class _MyHomePageState extends State<MyHomePage> {
               ),
               Text(
                 '$_counter',
-                style: Theme.of(context).textTheme.display1,
+                style: Theme.of(context).textTheme.headline4,
               ),
             ],
           ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,42 +7,63 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.1"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.12"
+    version: "1.15.0"
+  connectivity:
+    dependency: transitive
+    description:
+      name: connectivity
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.2"
+  connectivity_macos:
+    dependency: transitive
+    description:
+      name: connectivity_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
+  connectivity_platform_interface:
+    dependency: transitive
+    description:
+      name: connectivity_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   connectivity_widget:
     dependency: "direct main"
     description:
@@ -56,14 +77,14 @@ packages:
       name: cupertino_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2"
+    version: "1.0.2"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -80,56 +101,56 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.0+2"
+    version: "0.13.0"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.3"
+    version: "4.0.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.6"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0+1"
+    version: "1.11.0"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   rxdart:
     dependency: transitive
     description:
       name: rxdart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.24.1"
-  simple_connectivity:
-    dependency: transitive
-    description:
-      name: simple_connectivity
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.1"
+    version: "0.26.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -141,21 +162,21 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   stream_disposable:
     dependency: transitive
     description:
@@ -169,35 +190,35 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.16"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.9.0-14.0.dev <3.0.0"
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  dart: ">=2.12.0-259.9.beta <3.0.0"
+  flutter: ">=1.20.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -16,16 +16,18 @@ version: 1.0.0+1
 environment:
   sdk: ">=2.1.0 <3.0.0"
 
+publish_to: none
+
 dependencies:
   flutter:
     sdk: flutter
-
+  
   connectivity_widget:
     path: ../
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.2
+  cupertino_icons: ^1.0.2
 
 dev_dependencies:
   flutter_test:

--- a/lib/src/connectivity_bloc.dart
+++ b/lib/src/connectivity_bloc.dart
@@ -8,16 +8,15 @@ import 'event.dart';
 /// Bloc that holds the state of the [ConnectivityWidget] and verifies with
 /// the [ConnectivityUtils] if there is a connection to the internet
 class ConnectivityBloc {
-
   /// Connectivity status Stream
-  var connectivityStatusSubject = BehaviorSubject<bool>();
+  final connectivityStatusSubject = BehaviorSubject<bool>();
 
   Sink<bool> get connectivityStatusSink => connectivityStatusSubject.sink;
 
   Stream<bool> get connectivityStatusStream => connectivityStatusSubject.stream;
 
   /// Check the network status
-  var _checkInternetConnectivitySubject = PublishSubject<Event>();
+  final _checkInternetConnectivitySubject = PublishSubject<Event>();
 
   Sink<Event> get checkInternetConnectivitySink =>
       _checkInternetConnectivitySubject.sink;
@@ -25,9 +24,8 @@ class ConnectivityBloc {
   ConnectivityBloc._() {
     /// Listens for the value from [ConnectivityUtils] and sends a new event
     /// to the [ConnectivityWidget]
-    ConnectivityUtils.instance.isPhoneConnectedStream
-        .listen((value) {
-          if (value != null) connectivityStatusSink.add(value);
+    ConnectivityUtils.instance.isPhoneConnectedStream.listen((value) {
+      if (value != null) connectivityStatusSink.add(value);
     });
 
     _checkInternetConnectivitySubject.stream.listen((_) =>
@@ -38,5 +36,10 @@ class ConnectivityBloc {
 
   static ConnectivityBloc get instance {
     return _instance;
+  }
+
+  void dispose() {
+    _checkInternetConnectivitySubject?.close();
+    connectivityStatusSubject?.close();
   }
 }

--- a/lib/src/connectivity_util.dart
+++ b/lib/src/connectivity_util.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
-import 'dart:io';
 
-import 'package:simple_connectivity/simple_connectivity.dart';
+import 'package:connectivity/connectivity.dart';
 import 'package:rxdart/rxdart.dart';
 
 import 'package:http/http.dart' as http;
@@ -18,7 +17,7 @@ class ConnectivityUtils {
   /// Server to ping
   ///
   /// The server to ping and check the response, can be set with [setServerToPing]
-  String _serverToPing = "http://www.gstatic.com/generate_204";
+  List<String> _serverToPing = ["www.gstatic.com", "generate_204"];
 
   /// Verify Response Callback
   ///
@@ -26,7 +25,7 @@ class ConnectivityUtils {
   VerifyResponseCallback _callback = (_) => true;
 
   /// Sets a new server to ping
-  void setServerToPing(String serverToPing) {
+  void setServerToPing(List<String> serverToPing) {
     _serverToPing = serverToPing;
     _getConnectivityStatusSubject.add(Event());
   }
@@ -39,8 +38,10 @@ class ConnectivityUtils {
   static ConnectivityUtils _instance;
 
   /// Initializes the ConnectivityUtils instance by giving it a [serverToPing] and [callback]
-  static ConnectivityUtils initialize({String serverToPing, VerifyResponseCallback callback}) {
-    _instance = ConnectivityUtils._(serverToPing : serverToPing, callback : callback);
+  static ConnectivityUtils initialize(
+      {List<String> serverToPing, VerifyResponseCallback callback}) {
+    _instance =
+        ConnectivityUtils._(serverToPing: serverToPing, callback: callback);
     return _instance;
   }
 
@@ -51,13 +52,15 @@ class ConnectivityUtils {
     return _instance;
   }
 
-  ConnectivityUtils._({String serverToPing, VerifyResponseCallback callback}) {
-    this._serverToPing = serverToPing != null ? serverToPing : this._serverToPing;
+  ConnectivityUtils._(
+      {List<String> serverToPing, VerifyResponseCallback callback}) {
+    this._serverToPing =
+        serverToPing != null ? serverToPing : this._serverToPing;
     this._callback = callback != null ? callback : this._callback;
 
-    Connectivity().onConnectivityChanged.listen((_) =>
-        _getConnectivityStatusSubject.add(Event()), onError: (_) => _getConnectivityStatusSubject.add(Event())
-    );
+    Connectivity().onConnectivityChanged.listen(
+        (_) => _getConnectivityStatusSubject.add(Event()),
+        onError: (_) => _getConnectivityStatusSubject.add(Event()));
 
     /// Stream that receives events and verifies the network status
     _getConnectivityStatusSubject.stream
@@ -100,11 +103,13 @@ class ConnectivityUtils {
   /// internet
   Future<bool> isPhoneConnected() async {
     try {
-
       // ignore: close_sinks
-      final result = await http.get(_serverToPing);
-      if (result.statusCode > 199 && result.statusCode < 400 && _callback(result.body)) {
-        return true;
+      final httpsUri = Uri.https(_serverToPing[0], _serverToPing[1]);
+      final result = await http.get(httpsUri);
+      if (result.statusCode > 199 && result.statusCode < 400) {
+        if (_callback(result.body) == true) {
+          return true;
+        }
       }
     } catch (e) {
       return false;

--- a/lib/src/connectivity_widget.dart
+++ b/lib/src/connectivity_widget.dart
@@ -108,7 +108,9 @@ class ConnectivityWidgetState extends State<ConnectivityWidget>
         duration: const Duration(milliseconds: 500), vsync: this);
 
     if (dontAnimate == null &&
-        !(ConnectivityBloc.instance.connectivityStatusSubject.value ?? true)) {
+        !(ConnectivityBloc
+                .instance.connectivityStatusSubject.valueWrapper?.value ??
+            true)) {
       this.animationController.value = 1.0;
     }
 
@@ -117,7 +119,9 @@ class ConnectivityWidgetState extends State<ConnectivityWidget>
       /// At the start, if we have a status set, we must consider that we came from another screen with that status
       if (dontAnimate == null) {
         this.dontAnimate = true;
-        if (!(ConnectivityBloc.instance.connectivityStatusSubject.value ?? true)) {
+        if (!(ConnectivityBloc
+                .instance.connectivityStatusSubject.valueWrapper?.value ??
+            true)) {
           this.animationController.value = 1.0;
         }
         return;
@@ -136,28 +140,27 @@ class ConnectivityWidgetState extends State<ConnectivityWidget>
   @override
   Widget build(BuildContext context) {
     Widget child = StreamBuilder(
-      stream: ConnectivityBloc.instance.connectivityStatusStream,
-      builder: (context, snapshot) => Stack(
-        children: <Widget>[
-          widget.builder(context, snapshot.data ?? true),
-          if (widget.showOfflineBanner && !(snapshot.data ?? true))
-            Align(
-                alignment: Alignment.bottomCenter,
-                child: SlideTransition(
-                    position: animationController.drive(Tween<Offset>(
-                      begin: const Offset(0.0, 1.0),
-                      end: Offset.zero,
-                    ).chain(CurveTween(
-                      curve: Curves.fastOutSlowIn,
-                    ))),
-                    child: widget.offlineBanner ?? _NoConnectivityBanner()))
-        ],
-      )
-    );
+        stream: ConnectivityBloc.instance.connectivityStatusStream,
+        builder: (context, snapshot) => Stack(
+              children: <Widget>[
+                widget.builder(context, snapshot.data ?? true),
+                if (widget.showOfflineBanner && !(snapshot.data ?? true))
+                  Align(
+                      alignment: Alignment.bottomCenter,
+                      child: SlideTransition(
+                          position: animationController.drive(Tween<Offset>(
+                            begin: const Offset(0.0, 1.0),
+                            end: Offset.zero,
+                          ).chain(CurveTween(
+                            curve: Curves.fastOutSlowIn,
+                          ))),
+                          child:
+                              widget.offlineBanner ?? _NoConnectivityBanner()))
+              ],
+            ));
     return child;
   }
 }
-
 
 /// Default Banner for offline mode
 class _NoConnectivityBanner extends StatelessWidget {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,49 +7,70 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.1"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.12"
+    version: "1.15.0"
+  connectivity:
+    dependency: "direct main"
+    description:
+      name: connectivity
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.2"
+  connectivity_macos:
+    dependency: transitive
+    description:
+      name: connectivity_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
+  connectivity_platform_interface:
+    dependency: transitive
+    description:
+      name: connectivity_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -66,56 +87,56 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.0+2"
+    version: "0.13.0"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.3"
+    version: "4.0.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.6"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0+1"
+    version: "1.11.0"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   rxdart:
     dependency: "direct main"
     description:
       name: rxdart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.24.1"
-  simple_connectivity:
-    dependency: "direct main"
-    description:
-      name: simple_connectivity
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.1"
+    version: "0.26.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -127,21 +148,21 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   stream_disposable:
     dependency: "direct main"
     description:
@@ -155,35 +176,35 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.16"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.9.0-14.0.dev <3.0.0"
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  dart: ">=2.12.0-259.9.beta <3.0.0"
+  flutter: ">=1.20.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  rxdart: ^0.24.0
-  simple_connectivity: ^0.1.1
+  rxdart: ^0.26.0
+  connectivity: ^3.0.2
   stream_disposable: ^0.1.0
-  http: ^0.12.0+2
+  http: ^0.13.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
* Updating all packages on which the widget is dependent.
* Fixing bug in which the default version of the package doesn't work in Release mode on Android devices (Changing URL to ping to use HTTPS instead of HTTP which is forbidden in Android release mode)
* Switching deprecated and unmaintained 'simple_connctivity' package with null safety maintained 'connectivity' package
* Fixing Podfile for easy starting of the 'example' application