### PR TITLE
Updated http dependency

### DIFF
--- a/lib/src/connectivity_util.dart
+++ b/lib/src/connectivity_util.dart
@@ -39,8 +39,10 @@ class ConnectivityUtils {
   static ConnectivityUtils _instance;
 
   /// Initializes the ConnectivityUtils instance by giving it a [serverToPing] and [callback]
-  static ConnectivityUtils initialize({String serverToPing, VerifyResponseCallback callback}) {
-    _instance = ConnectivityUtils._(serverToPing : serverToPing, callback : callback);
+  static ConnectivityUtils initialize(
+      {String serverToPing, VerifyResponseCallback callback}) {
+    _instance =
+        ConnectivityUtils._(serverToPing: serverToPing, callback: callback);
     return _instance;
   }
 
@@ -52,12 +54,13 @@ class ConnectivityUtils {
   }
 
   ConnectivityUtils._({String serverToPing, VerifyResponseCallback callback}) {
-    this._serverToPing = serverToPing != null ? serverToPing : this._serverToPing;
+    this._serverToPing =
+        serverToPing != null ? serverToPing : this._serverToPing;
     this._callback = callback != null ? callback : this._callback;
 
-    Connectivity().onConnectivityChanged.listen((_) =>
-        _getConnectivityStatusSubject.add(Event()), onError: (_) => _getConnectivityStatusSubject.add(Event())
-    );
+    Connectivity().onConnectivityChanged.listen(
+        (_) => _getConnectivityStatusSubject.add(Event()),
+        onError: (_) => _getConnectivityStatusSubject.add(Event()));
 
     /// Stream that receives events and verifies the network status
     _getConnectivityStatusSubject.stream
@@ -100,10 +103,11 @@ class ConnectivityUtils {
   /// internet
   Future<bool> isPhoneConnected() async {
     try {
-
       // ignore: close_sinks
-      final result = await http.get(_serverToPing);
-      if (result.statusCode > 199 && result.statusCode < 400 && _callback(result.body)) {
+      final result = await http.get(Uri.parse(_serverToPing));
+      if (result.statusCode > 199 &&
+          result.statusCode < 400 &&
+          _callback(result.body)) {
         return true;
       }
     } catch (e) {

--- a/lib/src/connectivity_util.dart
+++ b/lib/src/connectivity_util.dart
@@ -39,10 +39,8 @@ class ConnectivityUtils {
   static ConnectivityUtils _instance;
 
   /// Initializes the ConnectivityUtils instance by giving it a [serverToPing] and [callback]
-  static ConnectivityUtils initialize(
-      {String serverToPing, VerifyResponseCallback callback}) {
-    _instance =
-        ConnectivityUtils._(serverToPing: serverToPing, callback: callback);
+  static ConnectivityUtils initialize({String serverToPing, VerifyResponseCallback callback}) {
+    _instance = ConnectivityUtils._(serverToPing : serverToPing, callback : callback);
     return _instance;
   }
 
@@ -54,13 +52,12 @@ class ConnectivityUtils {
   }
 
   ConnectivityUtils._({String serverToPing, VerifyResponseCallback callback}) {
-    this._serverToPing =
-        serverToPing != null ? serverToPing : this._serverToPing;
+    this._serverToPing = serverToPing != null ? serverToPing : this._serverToPing;
     this._callback = callback != null ? callback : this._callback;
 
-    Connectivity().onConnectivityChanged.listen(
-        (_) => _getConnectivityStatusSubject.add(Event()),
-        onError: (_) => _getConnectivityStatusSubject.add(Event()));
+    Connectivity().onConnectivityChanged.listen((_) =>
+        _getConnectivityStatusSubject.add(Event()), onError: (_) => _getConnectivityStatusSubject.add(Event())
+    );
 
     /// Stream that receives events and verifies the network status
     _getConnectivityStatusSubject.stream
@@ -103,11 +100,10 @@ class ConnectivityUtils {
   /// internet
   Future<bool> isPhoneConnected() async {
     try {
+
       // ignore: close_sinks
       final result = await http.get(Uri.parse(_serverToPing));
-      if (result.statusCode > 199 &&
-          result.statusCode < 400 &&
-          _callback(result.body)) {
+      if (result.statusCode > 199 && result.statusCode < 400 && _callback(result.body)) {
         return true;
       }
     } catch (e) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   rxdart: ^0.24.0
   simple_connectivity: ^0.1.1
   stream_disposable: ^0.1.0
-  http: ^0.12.0+2
+  http: ^0.13.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The latest Firebase plugins depend on `http: ^0.13.0`. 

`Because connectivity_widget >=0.1.4 depends on http ^0.12.0+2 and firebase >=9.0.0 depends on http ^0.13.0, connectivity_widget >=0.1.4 is incompatible with firebase >=9.0.0.
And because firebase_analytics >=8.0.4 depends on firebase_analytics_web ^0.3.0+1 which depends on firebase ^9.0.1, connectivity_widget >=0.1.4 is incompatible with firebase_analytics >=8.0.4.
So, because ecp depends on both connectivity_widget ^0.1.7 and firebase_analytics ^8.1.0, version solving failed.`

