### PR TITLE
feat: adds initial loading widget while waiting for connection result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [1.2.0]
+* By default, we show a loading indicator instead of assuming we have no internet connection
+
 # [1.1.0]
 * Fixes library tests
 * Adds [child] as a required parameter

--- a/lib/src/connectivity_utils.dart
+++ b/lib/src/connectivity_utils.dart
@@ -34,13 +34,12 @@ class ConnectivityUtils {
   late http.Client _httpClient;
 
   /// Connectivity on/off events
-  BehaviorSubject<bool> _connectivitySubject =
-      BehaviorSubject<bool>.seeded(false);
+  BehaviorSubject<bool> _connectivitySubject = BehaviorSubject<bool>();
 
   Stream<bool> get isPhoneConnectedStream =>
       _connectivitySubject.stream.distinct();
 
-  bool get getPhoneConnection => _connectivitySubject.value;
+  bool? get getPhoneConnection => _connectivitySubject.valueOrNull;
 
   /// Event to check the network status
   PublishSubject<Event> _getConnectivityStatusSubject = PublishSubject<Event>();

--- a/test/connectivity_utils_test.dart
+++ b/test/connectivity_utils_test.dart
@@ -157,7 +157,7 @@ void main() {
     });
 
     group('GetConnectivityStatus', () {
-      test('defaults to false', () async {
+      test('does not have a default value', () async {
         when(() => response.statusCode).thenReturn(200);
         when(() => response.body).thenReturn('bananas');
         when(() => client.get(Uri.parse(serverToPing))).thenAnswer(
@@ -167,7 +167,7 @@ void main() {
         );
         final utils = ConnectivityUtils.test(
             connectivity: connectivity, httpClient: client);
-        expectLater(utils.isPhoneConnectedStream, emitsInOrder([isFalse]));
+        expectLater(utils.isPhoneConnectedStream, emitsDone);
         await utils.dispose();
       });
 
@@ -187,7 +187,7 @@ void main() {
         expectLater(
           utils.isPhoneConnectedStream,
           emitsInOrder(
-            [isFalse, isTrue],
+            [isTrue],
           ),
         );
         await Future.delayed(Duration(seconds: 1));
@@ -206,8 +206,7 @@ void main() {
             connectivity: connectivity, httpClient: client);
         utils.serverToPing = serverToPing;
         utils.debounceDuration = duration;
-        expectLater(
-            utils.isPhoneConnectedStream, emitsInOrder([isFalse, isTrue]));
+        expectLater(utils.isPhoneConnectedStream, emitsInOrder([isTrue]));
         utils.getConnectivityStatusSink.add(Event());
         await Future.delayed(duration);
         await utils.dispose();
@@ -225,8 +224,8 @@ void main() {
             connectivity: connectivity, httpClient: client);
         utils.serverToPing = serverToPing;
         utils.debounceDuration = duration;
-        expectLater(utils.isPhoneConnectedStream,
-            emitsInOrder([isFalse, isTrue, isFalse]));
+        expectLater(
+            utils.isPhoneConnectedStream, emitsInOrder([isTrue, isFalse]));
         utils.getConnectivityStatusSink.add(Event());
         await Future.delayed(Duration(seconds: 1));
         const newServerToPing = 'https://my.app';


### PR DESCRIPTION
# [1.2.0]
* By default, we show a loading indicator instead of assuming we have no internet connection