### PR TITLE
feat: adds retries attempts before returning server call as false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [1.5.0]
+* Adds [retries] to retry connection to server [retries] times before setting connection as false. Defaults to 0.
+
 # [1.4.0]
 * Added the [timeoutDuration] parameter
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -71,7 +71,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.0"
+    version: "1.4.0"
   dbus:
     dependency: transitive
     description:
@@ -207,6 +207,14 @@ packages:
       url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "2.1.6"
+  retry:
+    dependency: transitive
+    description:
+      name: retry
+      sha256: "822e118d5b3aafed083109c72d5f484c6dc66707885e07c0fbcb8b986bba7efc"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+    source: hosted
+    version: "3.1.2"
   rxdart:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_widget
 description: A widget that shows the user if the phone is connected to the internet or not
-version: 1.4.0
+version: 1.5.0
 homepage: https://github.com/Vanethos/flutter_connectivity_widget/
 issue_tracker: https://github.com/Vanethos/flutter_connectivity_widget/issues
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   connectivity_plus: ^3.0.2
   stream_disposable: ^2.0.0
   http: ^0.13.5
+  retry: ^3.1.2
 
 dev_dependencies:
   flutter_test:

--- a/test/connectivity_utils_test.dart
+++ b/test/connectivity_utils_test.dart
@@ -259,6 +259,45 @@ void main() {
 
         await utils.dispose();
       });
+
+      test('if retries is set to 0, the server is pinged 1 time only on error',
+          () async {
+        when(() => client.get(Uri.parse(serverToPing))).thenAnswer(
+          (invocation) => Future.value(
+            response,
+          ),
+        );
+        when(() => response.statusCode).thenReturn(500);
+        when(() => response.body).thenReturn('bananas');
+        ConnectivityUtils.test(
+          connectivity: connectivity,
+          httpClient: client,
+          retries: 0,
+          serverToPing: serverToPing,
+        );
+        await Future.delayed(Duration(milliseconds: 500));
+        verify(() => client.get(Uri.parse(serverToPing))).called(1);
+      });
+
+      test(
+          'if retries is set to 4, the server is called 4 times before retrieving false',
+          () async {
+        when(() => client.get(Uri.parse(serverToPing))).thenAnswer(
+          (invocation) => Future.value(
+            response,
+          ),
+        );
+        when(() => response.statusCode).thenReturn(500);
+        when(() => response.body).thenReturn('bananas');
+        ConnectivityUtils.test(
+          connectivity: connectivity,
+          httpClient: client,
+          serverToPing: serverToPing,
+          retries: 4,
+        );
+        await Future.delayed(Duration(seconds: 3));
+        verify(() => client.get(Uri.parse(serverToPing))).called(4);
+      });
     });
   });
 }

--- a/test/connectivity_utils_test.dart
+++ b/test/connectivity_utils_test.dart
@@ -295,7 +295,7 @@ void main() {
           serverToPing: serverToPing,
           retries: 4,
         );
-        await Future.delayed(Duration(seconds: 3));
+        await Future.delayed(Duration(seconds: 5));
         verify(() => client.get(Uri.parse(serverToPing))).called(4);
       });
     });


### PR DESCRIPTION
**Description**
Adds new parameter that allows to retry the call [retries] times before setting connection as false. Useful in cases where internet connectivity can be unreliable and we don't want to constantly set the connection to false.