### PR TITLE
chore: [major] v3.0.0: upgrades connectivity_plus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [3.0.0]
+* Updates [connectivity_plus] package to version 6.0.3
+
 # [2.0.0]
 * Updates Dart SDK to support versions until the next SDK release (4.0.0)
 * Updates [http] package to version 1.2.1

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -6,7 +6,7 @@ packages:
     description:
       name: args
       sha256: "7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "2.5.0"
   async:
@@ -14,7 +14,7 @@ packages:
     description:
       name: async
       sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
   boolean_selector:
@@ -22,7 +22,7 @@ packages:
     description:
       name: boolean_selector
       sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   characters:
@@ -30,7 +30,7 @@ packages:
     description:
       name: characters
       sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   clock:
@@ -38,7 +38,7 @@ packages:
     description:
       name: clock
       sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
@@ -46,7 +46,7 @@ packages:
     description:
       name: collection
       sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.18.0"
   connectivity_plus:
@@ -54,7 +54,7 @@ packages:
     description:
       name: connectivity_plus
       sha256: db7a4e143dc72cc3cb2044ef9b052a7ebfe729513e6a82943bc3526f784365b8
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "6.0.3"
   connectivity_plus_platform_interface:
@@ -62,7 +62,7 @@ packages:
     description:
       name: connectivity_plus_platform_interface
       sha256: b6a56efe1e6675be240de39107281d4034b64ac23438026355b4234042a35adb
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   connectivity_widget:
@@ -77,7 +77,7 @@ packages:
     description:
       name: dbus
       sha256: "365c771ac3b0e58845f39ec6deebc76e3276aa9922b0cc60840712094d9047ac"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "0.7.10"
   fake_async:
@@ -85,7 +85,7 @@ packages:
     description:
       name: fake_async
       sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   ffi:
@@ -93,7 +93,7 @@ packages:
     description:
       name: ffi
       sha256: "493f37e7df1804778ff3a53bd691d8692ddf69702cf4c1c1096a2e41b4779e21"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
   flutter:
@@ -106,7 +106,7 @@ packages:
     description:
       name: flutter_lints
       sha256: "3f41d009ba7172d5ff9be5f6e6e6abb4300e263aab8866d2a0842ed2a70f8f0c"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
   flutter_test:
@@ -124,7 +124,7 @@ packages:
     description:
       name: http
       sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   http_parser:
@@ -132,7 +132,7 @@ packages:
     description:
       name: http_parser
       sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
   leak_tracker:
@@ -140,7 +140,7 @@ packages:
     description:
       name: leak_tracker
       sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "10.0.4"
   leak_tracker_flutter_testing:
@@ -148,7 +148,7 @@ packages:
     description:
       name: leak_tracker_flutter_testing
       sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
   leak_tracker_testing:
@@ -156,7 +156,7 @@ packages:
     description:
       name: leak_tracker_testing
       sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   lints:
@@ -164,7 +164,7 @@ packages:
     description:
       name: lints
       sha256: "976c774dd944a42e83e2467f4cc670daef7eed6295b10b36ae8c85bcbf828235"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
   matcher:
@@ -172,7 +172,7 @@ packages:
     description:
       name: matcher
       sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "0.12.16+1"
   material_color_utilities:
@@ -180,7 +180,7 @@ packages:
     description:
       name: material_color_utilities
       sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "0.8.0"
   meta:
@@ -188,7 +188,7 @@ packages:
     description:
       name: meta
       sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.12.0"
   nm:
@@ -196,7 +196,7 @@ packages:
     description:
       name: nm
       sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "0.5.0"
   path:
@@ -204,7 +204,7 @@ packages:
     description:
       name: path
       sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
   petitparser:
@@ -212,7 +212,7 @@ packages:
     description:
       name: petitparser
       sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "6.0.2"
   plugin_platform_interface:
@@ -220,7 +220,7 @@ packages:
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
   retry:
@@ -228,7 +228,7 @@ packages:
     description:
       name: retry
       sha256: "822e118d5b3aafed083109c72d5f484c6dc66707885e07c0fbcb8b986bba7efc"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
   rxdart:
@@ -236,7 +236,7 @@ packages:
     description:
       name: rxdart
       sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "0.27.7"
   sky_engine:
@@ -249,7 +249,7 @@ packages:
     description:
       name: source_span
       sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
   stack_trace:
@@ -257,7 +257,7 @@ packages:
     description:
       name: stack_trace
       sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.11.1"
   stream_channel:
@@ -265,7 +265,7 @@ packages:
     description:
       name: stream_channel
       sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
   stream_disposable:
@@ -273,7 +273,7 @@ packages:
     description:
       name: stream_disposable
       sha256: ed15757404db8f27be667dd9f9606cf5adb89911b7227b246638970f04b3515d
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   string_scanner:
@@ -281,7 +281,7 @@ packages:
     description:
       name: string_scanner
       sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   term_glyph:
@@ -289,7 +289,7 @@ packages:
     description:
       name: term_glyph
       sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
@@ -297,7 +297,7 @@ packages:
     description:
       name: test_api
       sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "0.7.0"
   typed_data:
@@ -305,7 +305,7 @@ packages:
     description:
       name: typed_data
       sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
   vector_math:
@@ -313,7 +313,7 @@ packages:
     description:
       name: vector_math
       sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
   vm_service:
@@ -321,7 +321,7 @@ packages:
     description:
       name: vm_service
       sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "14.2.1"
   web:
@@ -329,7 +329,7 @@ packages:
     description:
       name: web
       sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
   xml:
@@ -337,7 +337,7 @@ packages:
     description:
       name: xml
       sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
-      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "6.5.0"
 sdks:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,16 +5,16 @@ packages:
     dependency: transitive
     description:
       name: args
-      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
-      url: "https://pub.dev"
+      sha256: "7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0"
   async:
     dependency: transitive
     description:
       name: async
       sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "2.11.0"
   boolean_selector:
@@ -22,7 +22,7 @@ packages:
     description:
       name: boolean_selector
       sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "2.1.1"
   characters:
@@ -30,7 +30,7 @@ packages:
     description:
       name: characters
       sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "1.3.0"
   clock:
@@ -38,7 +38,7 @@ packages:
     description:
       name: clock
       sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "1.1.1"
   collection:
@@ -46,25 +46,25 @@ packages:
     description:
       name: collection
       sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "1.18.0"
   connectivity_plus:
     dependency: transitive
     description:
       name: connectivity_plus
-      sha256: "224a77051d52a11fbad53dd57827594d3bd24f945af28bd70bab376d68d437f0"
-      url: "https://pub.dev"
+      sha256: db7a4e143dc72cc3cb2044ef9b052a7ebfe729513e6a82943bc3526f784365b8
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
-    version: "5.0.2"
+    version: "6.0.3"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
       name: connectivity_plus_platform_interface
-      sha256: cf1d1c28f4416f8c654d7dc3cd638ec586076255d407cef3ddbdaf178272a71a
-      url: "https://pub.dev"
+      sha256: b6a56efe1e6675be240de39107281d4034b64ac23438026355b4234042a35adb
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
-    version: "1.2.4"
+    version: "2.0.0"
   connectivity_widget:
     dependency: "direct main"
     description:
@@ -77,7 +77,7 @@ packages:
     description:
       name: dbus
       sha256: "365c771ac3b0e58845f39ec6deebc76e3276aa9922b0cc60840712094d9047ac"
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "0.7.10"
   fake_async:
@@ -85,7 +85,7 @@ packages:
     description:
       name: fake_async
       sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "1.3.1"
   ffi:
@@ -93,7 +93,7 @@ packages:
     description:
       name: ffi
       sha256: "493f37e7df1804778ff3a53bd691d8692ddf69702cf4c1c1096a2e41b4779e21"
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "2.1.2"
   flutter:
@@ -105,10 +105,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: e2a421b7e59244faef694ba7b30562e489c2b489866e505074eb005cd7060db7
-      url: "https://pub.dev"
+      sha256: "3f41d009ba7172d5ff9be5f6e6e6abb4300e263aab8866d2a0842ed2a70f8f0c"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
-    version: "3.0.1"
+    version: "4.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -124,7 +124,7 @@ packages:
     description:
       name: http
       sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "1.2.1"
   http_parser:
@@ -132,55 +132,47 @@ packages:
     description:
       name: http_parser
       sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "4.0.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
-      url: "https://pub.dev"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
-      url: "https://pub.dev"
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
-      url: "https://pub.dev"
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
       name: lints
-      sha256: cbf8d4b858bb0134ef3ef87841abdf8d63bfc255c266b7bf6b39daa1085c4290
-      url: "https://pub.dev"
+      sha256: "976c774dd944a42e83e2467f4cc670daef7eed6295b10b36ae8c85bcbf828235"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
-    version: "3.0.0"
+    version: "4.0.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
       sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "0.12.16+1"
   material_color_utilities:
@@ -188,23 +180,23 @@ packages:
     description:
       name: material_color_utilities
       sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
-      url: "https://pub.dev"
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   nm:
     dependency: transitive
     description:
       name: nm
       sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "0.5.0"
   path:
@@ -212,7 +204,7 @@ packages:
     description:
       name: path
       sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "1.9.0"
   petitparser:
@@ -220,7 +212,7 @@ packages:
     description:
       name: petitparser
       sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "6.0.2"
   plugin_platform_interface:
@@ -228,7 +220,7 @@ packages:
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "2.1.8"
   retry:
@@ -236,7 +228,7 @@ packages:
     description:
       name: retry
       sha256: "822e118d5b3aafed083109c72d5f484c6dc66707885e07c0fbcb8b986bba7efc"
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "3.1.2"
   rxdart:
@@ -244,7 +236,7 @@ packages:
     description:
       name: rxdart
       sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "0.27.7"
   sky_engine:
@@ -257,7 +249,7 @@ packages:
     description:
       name: source_span
       sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "1.10.0"
   stack_trace:
@@ -265,7 +257,7 @@ packages:
     description:
       name: stack_trace
       sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "1.11.1"
   stream_channel:
@@ -273,7 +265,7 @@ packages:
     description:
       name: stream_channel
       sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "2.1.2"
   stream_disposable:
@@ -281,7 +273,7 @@ packages:
     description:
       name: stream_disposable
       sha256: ed15757404db8f27be667dd9f9606cf5adb89911b7227b246638970f04b3515d
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "2.0.0"
   string_scanner:
@@ -289,7 +281,7 @@ packages:
     description:
       name: string_scanner
       sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "1.2.0"
   term_glyph:
@@ -297,23 +289,23 @@ packages:
     description:
       name: term_glyph
       sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
-      url: "https://pub.dev"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "1.3.2"
   vector_math:
@@ -321,23 +313,23 @@ packages:
     description:
       name: vector_math
       sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
-      url: "https://pub.dev"
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   web:
     dependency: transitive
     description:
       name: web
       sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "0.5.1"
   xml:
@@ -345,9 +337,9 @@ packages:
     description:
       name: xml
       sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
-      url: "https://pub.dev"
+      url: "https://pvotaltech.jfrog.io/artifactory/api/pub/pvotal-pub/"
     source: hosted
     version: "6.5.0"
 sdks:
   dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_widget
 description: A widget that shows the user if the phone is connected to the internet or not
-version: 2.0.0
+version: 3.0.0
 homepage: https://github.com/Vanethos/flutter_connectivity_widget/
 issue_tracker: https://github.com/Vanethos/flutter_connectivity_widget/issues
 
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   rxdart: ^0.27.7
-  connectivity_plus: ^5.0.2
+  connectivity_plus: ^6.0.3
   stream_disposable: ^2.0.0
   http: ^1.2.1
   retry: ^3.1.2


### PR DESCRIPTION
Upgrades connectivity_plus to 6.0.3 so that this library can support apps that compile to WASM in flutter web